### PR TITLE
Fix characteristic checking, remove need for songloader dependency

### DIFF
--- a/NoArrowsRandom/NoArrowsRandomUI.cs
+++ b/NoArrowsRandom/NoArrowsRandomUI.cs
@@ -1,7 +1,6 @@
 ﻿using CustomUI.GameplaySettings;
 using CustomUI.Utilities;
 using IPA.Config;
-using SongLoaderPlugin.OverrideClasses;
 using System;
 using System.Collections;
 using System.Linq;
@@ -50,15 +49,13 @@ namespace NoArrowsRandom
             if (this.NoArrowsOption && BS_Utils.Plugin.LevelData.IsSet)
             {
                 GameplayCoreSceneSetupData data = BS_Utils.Plugin.LevelData?.GameplayCoreSceneSetupData;
-                var beatmap = data.difficultyBeatmap as CustomLevel.CustomDifficultyBeatmap;
-
-                if (beatmap == null) yield break; // Possibly not a custom map so abort
-
-                var charactersticList = beatmap.customLevel.beatmapCharacteristics.Select(c => c.characteristicName).ToList();
-                if (charactersticList.Contains("One Saber") || charactersticList.Contains("No Arrows"))
+                var beatmap = data.difficultyBeatmap;
+                string characteristic = beatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.characteristicName;
+             //   Logging.Info($"Characteristic: {characteristic}");
+                if (characteristic == ("One Saber") || characteristic == ("No Arrows"))
                 {
                     // Do not transform for One Saber or legitimate No Arrows mode
-                    Logging.Info($"Cannot transform song: {SongLoaderPlugin.SongLoader.CurrentLevelPlaying.customLevel.songName} in {String.Join(", ", charactersticList)} mode.");
+                    Logging.Info($"Cannot transform song: {beatmap.level.songName} due to being a One Saber or No Arrows map");
                     yield break;
                 }
 
@@ -69,7 +66,7 @@ namespace NoArrowsRandom
                 if (gameplayCore == null) yield break;
 
                 // Applying NoArrowsRandom transformation
-                Logging.Info($"Transforming song: {beatmap.customLevel.songName}");
+                Logging.Info($"Transforming song: {beatmap.level.songName}");
                 var transformedBeatmap = BeatmapDataNoArrowsTransform.CreateTransformedData(beatmap.beatmapData, true);
                 var beatmapDataModel = gameplayCore.GetPrivateField<BeatmapDataModel>("_beatmapDataModel");
                 beatmapDataModel.SetPrivateField("_beatmapData", transformedBeatmap);

--- a/NoArrowsRandom/Plugin.cs
+++ b/NoArrowsRandom/Plugin.cs
@@ -1,7 +1,6 @@
 ﻿using BS_Utils.Utilities;
 using IPA;
 using IPA.Config;
-using SongLoaderPlugin.OverrideClasses;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;

--- a/NoArrowsRandom/manifest.json
+++ b/NoArrowsRandom/manifest.json
@@ -6,5 +6,5 @@
   "gameVersion": "0.13.2",
   "id": "noarrowsrandom",
   "name": "NoArrowsRandom",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
The way you had characteristic checking set up meant any map that contained difficulties that were No Arrows or One Saber would be completely unable to be transformed, even if the difficulty being played was standard.  Also removed the references to songloader since those were unnecessary and means you can remove that dependency. Feel free to test and verify everything works in case I broke something 